### PR TITLE
fix: docker image minimal size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine
-RUN apk update
-RUN apk add rsync git bash
+FROM alpine:3
+
+RUN apk add --no-cache rsync git bash
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
- Pinned alpine version
- Install packages without cache

