### PR TITLE
Skip if no changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,9 +106,7 @@ rsync -a --quiet --delete --exclude ".git" "${SOURCE_PATH}/" "${TARGET_PATH}" ||
 
 # Check changes
 #
-CHANGED="$(git status -s)"
-
-if [ ! -z "${CHANGED}" ] ; then
+if [ -z "$(git status -s)" ] ; then
     echo "No changes, script exited"
     exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,6 +104,15 @@ echo "Populating ${TARGET_PATH}"
 mkdir -p "${TARGET_PATH}" || exit 1
 rsync -a --quiet --delete --exclude ".git" "${SOURCE_PATH}/" "${TARGET_PATH}" || exit 1
 
+# Check changes
+#
+CHANGED="$(git status -s)"
+
+if [ ! -z "${CHANGED}" ] ; then
+    echo "No changes, script exited"
+    exit 0
+fi
+
 # Create commit with changes.
 #
 echo "Creating commit"


### PR DESCRIPTION
Instead throwing error of `nothing to commit, working tree clean`, this PR makes the script just exit when no files changed to the dist repo. Resolves #9.