### PR TITLE
spelling: default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: ''
   source_folder:
     description: 'Source folder in workspace to copy (default: workspace root)'
-    defaault: ''
+    default: ''
   target_folder:
     description: 'Target folder in destination branch to copy to (default: repository root)'
     default: ''


### PR DESCRIPTION
Misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

It reported: https://github.com/jsoref/gha-publish-to-git/commit/09cd07b0305563db1a07c527d0ebf8d6ac0e6ce8

And it validated that the changes in this PR made it happy: https://github.com/jsoref/gha-publish-to-git/commit/51e4e5f035b1d8e2b0b99b62d8b02a295cc89fb1